### PR TITLE
Update example deploy_presto.json

### DIFF
--- a/examples/deploy_presto.json
+++ b/examples/deploy_presto.json
@@ -13,7 +13,7 @@
                         "type": "DOCKER",
                         "volumes": []
                     },
-                    "cpus": "0.4",
+                    "cpus": 0.4,
                     "env": {
                         "CATALOGS_URL": "http://my.local.machine/catalog.tar.gz",
                         "MARATHON_APPNAME": "discovery",
@@ -21,8 +21,8 @@
                         "MARATHON_URL": "http://my.marathon.master:8080"
                     },
                     "id": "/presto/meta/discovery",
-                    "instances": "1",
-                    "mem": "1024",
+                    "instances": 1,
+                    "mem": 1024,
                     "ports": [
                         0
                     ],
@@ -41,7 +41,7 @@
                         "type": "DOCKER",
                         "volumes": []
                     },
-                    "cpus": "0.4",
+                    "cpus": 0.4,
                     "env": {
                         "CATALOGS_URL": "http://my.local.machine/catalog.tar.gz",
                         "MARATHON_APPNAME": "coordinator",
@@ -49,8 +49,8 @@
                         "MARATHON_URL": "http://my.marathon.master:8080"
                     },
                     "id": "/presto/meta/coordinator",
-                    "instances": "1",
-                    "mem": "1024",
+                    "instances": 1,
+                    "mem": 1024,
                     "ports": [
                         0
                     ],
@@ -74,7 +74,7 @@
                         "type": "DOCKER",
                         "volumes": []
                     },
-                    "cpus": "2",
+                    "cpus": 2,
                     "env": {
                         "CATALOGS_URL": "http://my.local.machine/catalog.tar.gz",
                         "MARATHON_APPNAME": "worker",
@@ -82,8 +82,8 @@
                         "MARATHON_URL": "http://my.marathon.master:8080"
                     },
                     "id": "/presto/workers/worker",
-                    "instances": "1",
-                    "mem": "2048",
+                    "instances": 1,
+                    "mem": 2048,
                     "ports": [
                         0
                     ],


### PR DESCRIPTION
Instances, Memory, and CPUs need to be numbers and not strings. Marathon throws error otherwise.