### PR TITLE
Fix typo

### DIFF
--- a/docker/presto/confd/templates/node.properties.tmpl
+++ b/docker/presto/confd/templates/node.properties.tmpl
@@ -1,3 +1,3 @@
 node.environment={{getv "/presto/environment"}}
 node.id={{getv "/presto/uuid"}}
-node.data-dir=${{getv "/presto/datadir"}}
+node.data-dir={{getv "/presto/datadir"}}


### PR DESCRIPTION
Hi,  @sheepkiller.
I think that this "$" is mistype.

```
[root@example01 installation]# cat etc/node.properties
node.environment=dark_city
node.id=8b7de456-fc9f-49b5-b660-c9929a69d0ac
node.data-dir=$/var/presto/data
```